### PR TITLE
Refactor: Update WarehouseMovementResource and quantity handling

### DIFF
--- a/src/models/warehouseMovomentResource.ts
+++ b/src/models/warehouseMovomentResource.ts
@@ -15,7 +15,6 @@ class WarehouseMovementResource
   public movement_id!: string
   public warehouse_id!: string
   public resource_id!: string
-  public type!: string
   public movement_type!: string
   public quantity!: number
   public movement_date!: Date
@@ -37,10 +36,6 @@ WarehouseMovementResource.init(
     },
     resource_id: {
       type: DataTypes.UUID,
-      allowNull: false,
-    },
-    type: {
-      type: DataTypes.STRING,
       allowNull: false,
     },
     movement_type: {

--- a/src/schemas/almacen/warehouseMovomentResourceSchema.ts
+++ b/src/schemas/almacen/warehouseMovomentResourceSchema.ts
@@ -17,15 +17,11 @@ export const warehouseMovementResourceSchema = z.object({
     .uuid('El ID del recurso debe ser un UUID válido')
     .nonempty('El ID del recurso no puede estar vacío'),
 
-  type: z
-    .string()
-    .min(1, 'El tipo de movimiento es obligatorio')
-    .max(50, 'El tipo de movimiento no debe exceder los 50 caracteres'),
-
-  movement_type: z
-    .string()
-    .min(1, 'El tipo de movimiento es obligatorio')
-    .max(50, 'El tipo de movimiento no debe exceder los 50 caracteres'),
+  movement_type: z.enum(['salida', 'entrada'], {
+    errorMap: () => ({
+      message: 'El tipo de movimiento debe ser "salida" o "entrada"',
+    }),
+  }),
 
   quantity: z
     .number({ invalid_type_error: 'La cantidad debe ser un número' })

--- a/src/services/warehouseMovementResource/serviceCreateWarehouseMovementResource.ts
+++ b/src/services/warehouseMovementResource/serviceCreateWarehouseMovementResource.ts
@@ -1,6 +1,7 @@
 import WarehouseMovementResource from '@models/warehouseMovomentResource'
 import { WarehouseMovomentResourceAttributes } from '@type/almacen/warehouse_movoment_resource'
 import { warehouseMovementResourceValidation } from 'src/schemas/almacen/warehouseMovomentResourceSchema'
+import WarehouseResource from '@models/warehouseResource' // Added import
 
 const serviceCreateWarehouseMovementResource = async (
   body: WarehouseMovomentResourceAttributes,
@@ -15,25 +16,53 @@ const serviceCreateWarehouseMovementResource = async (
     movement_id,
     warehouse_id,
     resource_id,
-    type,
+    // type, // Removed type
     movement_type,
     quantity,
     movement_date,
     observations,
   } = validation.data
 
+  // Find or create WarehouseResource
+  let warehouseResource = await WarehouseResource.findOne({
+    where: { warehouse_id, resource_id },
+  })
+
+  if (movement_type === 'salida') {
+    if (!warehouseResource || warehouseResource.quantity < quantity) {
+      return {
+        error:
+          'No hay suficiente cantidad en el almacén para realizar la salida o el recurso no existe en el almacén.',
+      }
+    }
+    warehouseResource.quantity -= quantity
+    await warehouseResource.save()
+  } else if (movement_type === 'entrada') {
+    if (warehouseResource) {
+      warehouseResource.quantity += quantity
+      await warehouseResource.save()
+    } else {
+      warehouseResource = await WarehouseResource.create({
+        warehouse_id,
+        resource_id,
+        quantity,
+        entry_date: new Date(), // Assuming entry_date should be now
+      })
+    }
+  }
+
   const newRecord = await WarehouseMovementResource.create({
     movement_id,
     warehouse_id,
     resource_id,
-    type,
+    // type, // Removed type
     movement_type,
     quantity,
     movement_date,
     observations: observations ?? null,
   })
 
-  return newRecord
+  return { newRecord, warehouseResource } // Return both records
 }
 
 export default serviceCreateWarehouseMovementResource

--- a/src/tests/services/warehouseMovementResource/serviceCreateWarehouseMovementResource.test.ts
+++ b/src/tests/services/warehouseMovementResource/serviceCreateWarehouseMovementResource.test.ts
@@ -1,0 +1,325 @@
+import serviceCreateWarehouseMovementResource from '@services/warehouseMovementResource/serviceCreateWarehouseMovementResource'
+import WarehouseMovementResource from '@models/warehouseMovomentResource'
+import WarehouseResource from '@models/warehouseResource'
+import { v4 as uuid } from 'uuid'
+
+// Mock the models
+jest.mock('@models/warehouseMovomentResource')
+jest.mock('@models/warehouseResource')
+
+const mockWarehouseMovementResourceCreate = WarehouseMovementResource.create as jest.Mock
+const mockWarehouseResourceFindOne = WarehouseResource.findOne as jest.Mock
+const mockWarehouseResourceCreate = WarehouseResource.create as jest.Mock
+// Mock the save method on instances of WarehouseResource
+const mockWarehouseResourceSave = jest.fn()
+
+describe('serviceCreateWarehouseMovementResource', () => {
+  beforeEach(() => {
+    // Clear all mock calls and instances before each test
+    jest.clearAllMocks()
+
+    // Reset mock implementations if needed, or provide default successful implementations
+    mockWarehouseMovementResourceCreate.mockResolvedValue({
+      movement_id: uuid(),
+      warehouse_id: uuid(),
+      resource_id: uuid(),
+      movement_type: 'entrada',
+      quantity: 10,
+      movement_date: new Date(),
+      observations: null,
+      toJSON: () => ({}), // Add toJSON if your service uses it
+    } as any)
+
+    // Setup default mock for findOne to return null (resource not found)
+    mockWarehouseResourceFindOne.mockResolvedValue(null)
+    // Setup default mock for create
+    mockWarehouseResourceCreate.mockImplementation((data: any) =>
+      Promise.resolve({ ...data, id: uuid(), save: mockWarehouseResourceSave, toJSON: () => ({}) }),
+    )
+    // Setup default mock for save
+    mockWarehouseResourceSave.mockResolvedValue({} as any) // Adjust if save returns something specific
+  })
+
+  // Test case 1: Entrada - successful creation and update
+  it('should create a new movement and update WarehouseResource for "entrada"', async () => {
+    const warehouse_id = uuid()
+    const resource_id = uuid()
+    const initialQuantity = 50
+    const movementQuantity = 10
+
+    mockWarehouseResourceFindOne.mockResolvedValueOnce({
+      id: uuid(),
+      warehouse_id,
+      resource_id,
+      quantity: initialQuantity,
+      save: mockWarehouseResourceSave,
+      toJSON: () => ({ quantity: initialQuantity + movementQuantity }),
+    })
+
+    const body = {
+      warehouse_id,
+      resource_id,
+      movement_type: 'entrada',
+      quantity: movementQuantity,
+      movement_date: new Date(),
+      movement_id: uuid(), // movement_id is optional in attributes but schema expects it
+    }
+
+    const result = await serviceCreateWarehouseMovementResource(body as any)
+
+    expect(mockWarehouseResourceFindOne).toHaveBeenCalledWith({
+      where: { warehouse_id, resource_id },
+    })
+    expect(mockWarehouseResourceSave).toHaveBeenCalled()
+    expect(mockWarehouseMovementResourceCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ...body,
+        observations: null, // Ensure observations is handled
+      }),
+    )
+    expect(result.warehouseResource?.toJSON().quantity).toBe(initialQuantity + movementQuantity)
+    expect(result.newRecord).toBeDefined()
+  })
+
+  // Test case 2: Salida - successful creation and update
+  it('should create a new movement and update WarehouseResource for "salida" with sufficient quantity', async () => {
+    const warehouse_id = uuid()
+    const resource_id = uuid()
+    const initialQuantity = 50
+    const movementQuantity = 10
+
+    const mockWarehouseResourceInstance = {
+      id: uuid(),
+      warehouse_id,
+      resource_id,
+      quantity: initialQuantity,
+      save: mockWarehouseResourceSave,
+      toJSON: () => ({ quantity: initialQuantity - movementQuantity }),
+    }
+    mockWarehouseResourceFindOne.mockResolvedValueOnce(mockWarehouseResourceInstance)
+
+    const body = {
+      warehouse_id,
+      resource_id,
+      movement_type: 'salida',
+      quantity: movementQuantity,
+      movement_date: new Date(),
+      movement_id: uuid(),
+    }
+
+    const result = await serviceCreateWarehouseMovementResource(body as any)
+
+    expect(mockWarehouseResourceFindOne).toHaveBeenCalledWith({
+      where: { warehouse_id, resource_id },
+    })
+    expect(mockWarehouseResourceInstance.save).toHaveBeenCalled()
+    expect(mockWarehouseMovementResourceCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ...body,
+        observations: null,
+      }),
+    )
+    expect(result.warehouseResource?.toJSON().quantity).toBe(initialQuantity - movementQuantity)
+    expect(result.newRecord).toBeDefined()
+  })
+
+  // Test case 3: Salida - insufficient quantity
+  it('should return an error for "salida" with insufficient quantity', async () => {
+    const warehouse_id = uuid()
+    const resource_id = uuid()
+    const initialQuantity = 5
+    const movementQuantity = 10
+
+    mockWarehouseResourceFindOne.mockResolvedValueOnce({
+      id: uuid(),
+      warehouse_id,
+      resource_id,
+      quantity: initialQuantity,
+      save: mockWarehouseResourceSave,
+    })
+
+    const body = {
+      warehouse_id,
+      resource_id,
+      movement_type: 'salida',
+      quantity: movementQuantity,
+      movement_date: new Date(),
+      movement_id: uuid(),
+    }
+
+    const result = await serviceCreateWarehouseMovementResource(body as any)
+
+    expect(mockWarehouseResourceFindOne).toHaveBeenCalledWith({
+      where: { warehouse_id, resource_id },
+    })
+    expect(result.error).toBeDefined()
+    expect(result.error).toContain('No hay suficiente cantidad')
+    expect(mockWarehouseResourceSave).not.toHaveBeenCalled()
+    expect(mockWarehouseMovementResourceCreate).not.toHaveBeenCalled()
+  })
+
+  // Test case 4: Salida - WarehouseResource does not exist
+  it('should return an error for "salida" if WarehouseResource does not exist', async () => {
+    const warehouse_id = uuid()
+    const resource_id = uuid()
+    const movementQuantity = 10
+
+    // findOne returns null by default based on beforeEach setup
+    mockWarehouseResourceFindOne.mockResolvedValueOnce(null)
+
+    const body = {
+      warehouse_id,
+      resource_id,
+      movement_type: 'salida',
+      quantity: movementQuantity,
+      movement_date: new Date(),
+      movement_id: uuid(),
+    }
+
+    const result = await serviceCreateWarehouseMovementResource(body as any)
+
+    expect(mockWarehouseResourceFindOne).toHaveBeenCalledWith({
+      where: { warehouse_id, resource_id },
+    })
+    expect(result.error).toBeDefined()
+    expect(result.error).toContain('No hay suficiente cantidad')
+    expect(mockWarehouseResourceCreate).not.toHaveBeenCalled()
+    expect(mockWarehouseMovementResourceCreate).not.toHaveBeenCalled()
+  })
+
+  // Test case 5: Entrada - WarehouseResource does not exist, should create it
+  it('should create WarehouseResource if it does not exist for "entrada"', async () => {
+    const warehouse_id = uuid()
+    const resource_id = uuid()
+    const movementQuantity = 20
+
+    // findOne returns null by default
+    mockWarehouseResourceFindOne.mockResolvedValueOnce(null)
+    // create returns a new resource
+    const createdWarehouseResource = {
+      id: uuid(),
+      warehouse_id,
+      resource_id,
+      quantity: movementQuantity,
+      entry_date: expect.any(Date),
+      save: mockWarehouseResourceSave,
+      toJSON: () => ({ quantity: movementQuantity }),
+    }
+    mockWarehouseResourceCreate.mockResolvedValueOnce(createdWarehouseResource)
+
+
+    const body = {
+      warehouse_id,
+      resource_id,
+      movement_type: 'entrada',
+      quantity: movementQuantity,
+      movement_date: new Date(),
+      movement_id: uuid(),
+    }
+
+    const result = await serviceCreateWarehouseMovementResource(body as any)
+
+    expect(mockWarehouseResourceFindOne).toHaveBeenCalledWith({
+      where: { warehouse_id, resource_id },
+    })
+    expect(mockWarehouseResourceCreate).toHaveBeenCalledWith({
+      warehouse_id,
+      resource_id,
+      quantity: movementQuantity,
+      entry_date: expect.any(Date), // service sets this
+    })
+    expect(mockWarehouseMovementResourceCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ...body,
+        observations: null,
+      }),
+    )
+    expect(result.warehouseResource?.toJSON().quantity).toBe(movementQuantity)
+    expect(result.newRecord).toBeDefined()
+  })
+
+  // Test case 6: Invalid movement_type
+  it('should return a validation error for invalid movement_type', async () => {
+    const body = {
+      warehouse_id: uuid(),
+      resource_id: uuid(),
+      movement_type: 'invalid_type', // Invalid type
+      quantity: 10,
+      movement_date: new Date(),
+      movement_id: uuid(),
+    }
+
+    const result = await serviceCreateWarehouseMovementResource(body as any)
+
+    expect(result.error).toBeDefined()
+    expect(result.error[0].message).toContain('El tipo de movimiento debe ser "salida" o "entrada"')
+    expect(mockWarehouseMovementResourceCreate).not.toHaveBeenCalled()
+  })
+
+  // Test case 7: Missing required fields (e.g., warehouse_id)
+  it('should return a validation error if warehouse_id is missing', async () => {
+    const body = {
+      // warehouse_id: uuid(), // Missing
+      resource_id: uuid(),
+      movement_type: 'entrada',
+      quantity: 10,
+      movement_date: new Date(),
+      movement_id: uuid(),
+    }
+
+    const result = await serviceCreateWarehouseMovementResource(body as any)
+    expect(result.error).toBeDefined()
+    // Zod errors path will show ['warehouse_id']
+    expect(result.error[0].path).toContain('warehouse_id')
+    expect(result.error[0].message).toBe('El ID del almacén no puede estar vacío')
+    expect(mockWarehouseMovementResourceCreate).not.toHaveBeenCalled()
+  })
+
+  it('should return a validation error if resource_id is missing', async () => {
+    const body = {
+      warehouse_id: uuid(),
+      // resource_id: uuid(), // Missing
+      movement_type: 'entrada',
+      quantity: 10,
+      movement_date: new Date(),
+      movement_id: uuid(),
+    }
+
+    const result = await serviceCreateWarehouseMovementResource(body as any)
+    expect(result.error).toBeDefined()
+    expect(result.error[0].path).toContain('resource_id')
+    expect(result.error[0].message).toBe('El ID del recurso no puede estar vacío')
+  })
+
+  it('should return a validation error if quantity is negative', async () => {
+    const body = {
+      warehouse_id: uuid(),
+      resource_id: uuid(),
+      movement_type: 'entrada',
+      quantity: -5, // Invalid
+      movement_date: new Date(),
+      movement_id: uuid(),
+    }
+
+    const result = await serviceCreateWarehouseMovementResource(body as any)
+    expect(result.error).toBeDefined()
+    expect(result.error[0].path).toContain('quantity')
+    expect(result.error[0].message).toBe('La cantidad no puede ser negativa')
+  })
+
+  it('should return a validation error if movement_date is invalid', async () => {
+    const body = {
+      warehouse_id: uuid(),
+      resource_id: uuid(),
+      movement_type: 'entrada',
+      quantity: 5,
+      movement_date: 'not-a-date', // Invalid
+      movement_id: uuid(),
+    }
+
+    const result = await serviceCreateWarehouseMovementResource(body as any)
+    expect(result.error).toBeDefined()
+    expect(result.error[0].path).toContain('movement_date')
+    expect(result.error[0].message).toBe('La fecha del movimiento debe ser válida')
+  })
+})

--- a/src/types/almacen/warehouse_movoment_resource.d.ts
+++ b/src/types/almacen/warehouse_movoment_resource.d.ts
@@ -2,7 +2,6 @@ export interface WarehouseMovomentResourceAttributes {
   movement_id: string
   warehouse_id: string
   resource_id: string
-  type: string
   movement_type: string
   quantity: number
   movement_date: Date


### PR DESCRIPTION
- I removed the `type` field from `WarehouseMovementResource` model, schema, and type definitions.
- I updated `movement_type` in `warehouseMovementResourceSchema` to only accept "salida" (exit) or "entrada" (entry).
- I modified `serviceCreateWarehouseMovementResource` to:
    - Update `WarehouseResource.quantity` based on `movement_type`.
    - If "entrada", the quantity of the resource in the warehouse is increased. A new `WarehouseResource` record is created if it doesn't exist.
    - If "salida", the quantity of the resource in the warehouse is decreased. An error is returned if there's insufficient quantity or if the `WarehouseResource` doesn't exist.
    - The quantity in `WarehouseResource` cannot go below zero.
- I added comprehensive unit tests for `serviceCreateWarehouseMovementResource` to cover successful operations, error handling for insufficient stock, and validation of input data.